### PR TITLE
make parser.py compatible python 2.6

### DIFF
--- a/inlines/parser.py
+++ b/inlines/parser.py
@@ -66,7 +66,8 @@ def render_inline(inline):
             return ''
 
     # Create the context with all the attributes in the inline markup.
-    context = {k: v for k, v in inline.attrs}
+    # context = {k: v for k, v in inline.attrs}
+    for (k, v) in inline.attrs: context[k] = v
 
     # If multiple IDs were specified, build a list of all requested objects
     # and add them to the context.


### PR DESCRIPTION
I tried the code on two computers, one running python 2.7 and the other one 2.6. The first works just fine but the second fails with the error invalid syntax (parser.py, line 69).

The line 69 contains the following code context = {k: v for k, v in inline.attrs} which seems not to be possible in python 2.6.

I hope it's the only incompatibility. Python 2.6 is still present on lot's of computers (eg: Debian) and may be good to keep with this version.
