### PR TITLE
if possible, use BeautifulSoup v4

### DIFF
--- a/inlines/parser.py
+++ b/inlines/parser.py
@@ -9,11 +9,16 @@ from django.utils.safestring import mark_safe
 
 def inlines(value, return_list=False):
     try:
-        from BeautifulSoup import BeautifulStoneSoup
-    except ImportError:
-        from beautifulsoup import BeautifulStoneSoup
-
-    content = BeautifulStoneSoup(value, selfClosingTags=['inline', 'img', 'br',
+        # BeautifulSoup v4
+        from bs4 import BeautifulSoup
+        content = BeautifulSoup(value, features="html")
+    except ImportError:        
+        # BeautifulSoup v3
+        try:
+            from BeautifulSoup import BeautifulStoneSoup
+        except ImportError:
+            from beautifulsoup import BeautifulStoneSoup
+        content = BeautifulStoneSoup(value, selfClosingTags=['inline', 'img', 'br',
                                                          'input', 'meta',
                                                          'link', 'hr'])
 


### PR DESCRIPTION
The 4th version of BeautifulSoup seems to handle better malformed HTML. It should be used whenever possible. Not sure about the argument `features` though. Tested on python 2.6 and 2.7.
